### PR TITLE
fix: prevent SPA routing from redirecting Open Graph assets

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
 import { Routes, Route, Navigate } from 'react-router-dom';
 import { Header } from './components/Header';
-
 import Login from './pages/Login';
 
 export default function App() {
@@ -9,26 +8,33 @@ export default function App() {
 			<Header />
 
 			<Routes>
-				{/* Default route */}
+				{/* Home */}
 				<Route path="/" element={<Navigate to="/login" replace />} />
 
 				{/* Auth */}
 				<Route path="/login" element={<Login />} />
 
-				{/* Placeholder dashboard */}
+				{/* Dashboard */}
 				<Route
 					path="/dashboard"
 					element={
 						<div className="app-container py-8">
-							<h1 className="text-2xl font-semibold">
-								Dashboard
-							</h1>
+							<h1 className="text-2xl font-semibold">Dashboard</h1>
 						</div>
 					}
 				/>
 
-				{/* Catch-all */}
-				<Route path="*" element={<Navigate to="/login" replace />} />
+				{/* 🚨 IMPORTANT: do NOT redirect everything */}
+				<Route
+					path="*"
+					element={
+						<div className="app-container py-8">
+							<h1 className="text-xl font-semibold">
+								404 – Page not found
+							</h1>
+						</div>
+					}
+				/>
 			</Routes>
 		</div>
 	);

--- a/vercel.json
+++ b/vercel.json
@@ -8,7 +8,7 @@
       "continue": true
     },
     {
-      "src": "^/(.*)$",
+      "src": "^(?!/og/).*",
       "dest": "/index.html"
     }
   ]


### PR DESCRIPTION
## Summary

## 🐛 Fix Open Graph asset routing

### Problem
Requests to Open Graph assets (e.g. `/og/omkraft-og.png`) were being
incorrectly handled by the React SPA:

- Vercel routed the request to `index.html`
- React Router catch-all (`*`) redirected to `/login`
- Bots (WhatsApp / Meta / Slack) received HTML instead of the image
- Link previews failed to render correctly

---

### Solution
This change ensures Open Graph assets bypass the SPA entirely:

- Updated React Router to remove catch-all redirects
- Replaced redirect-based fallback with a safe 404 page
- Updated Vercel routing to explicitly allow `/og/*` to be served as static assets
- Preserved SPA behavior for all application routes

---

### Result
- `/og/*` assets are publicly accessible
- No auth or SPA redirects for bots
- WhatsApp / Meta / social previews render correctly
- No impact on authenticated application routes

---

### Verification
- [x] Direct access to `/og/omkraft-og.png` returns image (HTTP 200)
- [x] No redirect to `/login`
- [x] Meta Sharing Debugger shows explicit `og:image`
- [x] SPA routing continues to function as expected

---

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Refactor
- [ ] 📚 Documentation
- [ ] 🔧 Chore

---

## Checklist
- [x] Code follows Omkraft standards
- [x] ESLint passes locally
- [x] Tests added/updated (if applicable)
- [x] No breaking changes (or documented)

---

## Screenshots / Logs (if applicable)

---

## Related Issues
Closes #
