### PR TITLE
chore: use stable Vercel production URL for OG previews

### DIFF
--- a/index.html
+++ b/index.html
@@ -22,10 +22,12 @@
 		<meta property="og:description"
 					content="Omkraft builds thoughtfully engineered systems with precision, performance, and clarity." />
 		<meta property="og:type" content="website" />
+		<meta property="og:site_name" content="Omkraft Inc." />
 		<meta property="og:url"
-					content="https://app-q92hom8td-omkar-desais-projects-4fc143cb.vercel.app/login?v=2" />
+					content="https://app-ui-phi.vercel.app/login?v=2" />
 		<meta property="og:image"
-					content="https://app-q92hom8td-omkar-desais-projects-4fc143cb.vercel.app/og/omkraft-og.png" />
+					content="https://app-ui-phi.vercel.app/og/omkraft-og.png" />
+		<meta property="og:image:secure_url" content="https://app-ui-phi.vercel.app/og/omkraft-og.png" />
 		<meta property="og:image:type" content="image/png" />
 		<meta property="og:image:width" content="1200" />
 		<meta property="og:image:height" content="630" />
@@ -36,7 +38,7 @@
 		<meta name="twitter:description"
 					content="Omkraft builds thoughtfully engineered systems with precision, performance, and clarity." />
 		<meta name="twitter:image"
-					content="https://app-52i9yb55x-omkar-desais-projects-4fc143cb.vercel.app/og-image.png" />
+					content="https://app-ui-phi.vercel.app/og/omkraft-og.png" />
 
 		<!-- Favicon -->
 		<link rel="icon" href="/favicon.ico" />


### PR DESCRIPTION
## Summary

This PR fixes social link preview stability by switching all Open Graph
and preview-related URLs to the **stable Vercel production domain** instead of
deployment-specific preview URLs.

This eliminates the need to update meta tags on every deployment and ensures
consistent previews across platforms.

---

## Problem

Vercel generates a new, immutable deployment URL on every build
(e.g. `app-xxxx.vercel.app`).

Using these URLs in OG meta tags caused:
- Broken or stale previews after redeployments
- Confusion when sharing links
- Manual updates to `index.html` after each deploy

---

## Solution

- Replaced all deployment-specific URLs with the stable production domain:
  - `https://<project-name>.vercel.app`
- Ensured OG image and URL references are deployment-agnostic
- Locked previews to the `main` (production) branch behavior

---

## Result

- Stable link previews across deployments
- No manual meta tag updates required
- Correct previews on:
  - WhatsApp
  - Facebook
  - Microsoft Teams
- Cleaner, production-grade setup without custom domains or CI hacks

---

## Notes

- This approach intentionally avoids reverse commits or build-time mutations
- Preview deployments may still exist, but production sharing is now canonical
- No functional application logic was changed

This aligns with Vercel and SPA best practices for social previews.

---

## Type of Change
- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Refactor
- [ ] 📚 Documentation
- [x] 🔧 Chore

---

## Checklist
- [x] Code follows Omkraft standards
- [x] ESLint passes locally
- [x] Tests added/updated (if applicable)
- [x] No breaking changes (or documented)

---

## Screenshots / Logs (if applicable)

---

## Related Issues
Closes #
