### PR TITLE
fix(auth): prevent refresh retry on login and public auth routes

### DIFF
--- a/src/api/auth.ts
+++ b/src/api/auth.ts
@@ -16,7 +16,7 @@ export function login(email: string, password: string): Promise<AuthResponse> {
 	return apiRequest<AuthResponse>('/api/auth/login', {
 		method: 'POST',
 		body: JSON.stringify({ email, password }),
-	});
+	}, { skipAuthRefresh: true });
 }
 
 export function register(

--- a/src/pages/Login.tsx
+++ b/src/pages/Login.tsx
@@ -9,6 +9,7 @@ import { Label } from '@/components/ui/label';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 
 import loginIllustration from '@/assets/login-illustration.svg';
+import Loading from './Loading';
 
 export default function Login() {
 	const [email, setEmail] = useState('');
@@ -22,114 +23,129 @@ export default function Login() {
 	const handleSubmit = async (e: React.FormEvent) => {
 		e.preventDefault();
 		setError(null);
-		setLoading(true);
+		let error = null;
+
+		if (
+			!email.trim() ||
+			!password.trim()
+		) {
+			setError('All fields are required');
+			return;
+		}
 
 		try {
+			setLoading(true);
 			const { token, user } = await loginApi(email, password);
 			login(token, user);
-			navigate('/dashboard', { replace: true });
 		} catch (err) {
-			setError(
-				err instanceof Error
-					? err.message
-					: 'Login failed. Please try again.'
-			);
+			error = err instanceof Error
+				? err.message
+				: 'Login failed. Please try again.';
+			setError(error);
 		} finally {
 			setLoading(false);
+			if (!error) {
+				navigate('/dashboard', { replace: true });
+			}
 		}
 	};
 
 
 	return (
-		<div className="min-h-[calc(100vh-72px)] bg-background text-foreground flex items-center">
-			<div className="app-container grid gap-12 lg:grid-cols-2 items-center justify-items-center">
-				{/* Left visual panel */}
-				<div className="hidden lg:block relative">
+		<>
+			{!loading ? (
+				<div className="min-h-[calc(100vh-72px)] bg-background text-foreground flex items-center">
+					<div className="app-container grid gap-12 lg:grid-cols-2 items-center justify-items-center">
+						{/* Left visual panel */}
+						<div className="hidden lg:block relative">
 
-					<div className="relative space-y-6">
-						<h1 className="text-4xl font-semibold text-foreground leading-tight">
-							Welcome to<br />
-							<span className="text-primary">Omkraft</span>
-						</h1>
+							<div className="relative space-y-6">
+								<h1 className="text-4xl font-semibold text-foreground leading-tight">
+									Welcome to<br />
+									<span className="text-primary">Omkraft</span>
+								</h1>
 
-						<p className="text-muted-foreground max-w-md">
-							Sign in to access your workspace and continue exploring a clean, scalable foundation.
-						</p>
+								<p className="text-muted-foreground max-w-md">
+									Sign in to access your workspace and continue exploring a clean, scalable foundation.
+								</p>
 
-						<img
-							src={loginIllustration}
-							alt="Login illustration"
-							className="w-full max-w-md opacity-90"
-						/>
+								<img
+									src={loginIllustration}
+									alt="Login illustration"
+									className="w-full max-w-md opacity-90"
+								/>
 
+							</div>
+						</div>
+
+						{/* Login card */}
+						<Card className="w-full max-w-md">
+							<CardHeader>
+								<CardTitle>
+									<h2>Sign in</h2>
+								</CardTitle>
+								<CardDescription>
+									Access your Omkraft workspace
+								</CardDescription>
+							</CardHeader>
+							<CardContent>
+								<form onSubmit={handleSubmit} className="space-y-4">
+									<div className="space-y-2">
+										<Label htmlFor="email">Email</Label>
+										<Input
+											id="email"
+											type="email"
+											placeholder="you@omkraft.io"
+											value={email}
+											onChange={(e) => setEmail(e.target.value)}
+											required
+										/>
+									</div>
+
+									<div className="space-y-2">
+										<Label htmlFor="password">Password</Label>
+										<Input
+											id="password"
+											type="password"
+											value={password}
+											onChange={(e) => setPassword(e.target.value)}
+											required
+										/>
+									</div>
+
+									{error && (
+										<p className="text-sm text-destructive">
+											{error}
+										</p>
+									)}
+
+									<Button
+										type="submit"
+										className="w-full"
+									>
+										Login
+									</Button>
+
+									<p className="text-sm text-center text-muted-foreground mt-4">
+										<Link to="/forgot-password" className="text-white underline">
+											Forgot Password?
+										</Link>
+									</p>
+
+									<p className="text-sm text-center text-muted-foreground mt-4">
+										Don't have an account?{' '}
+										<Link to="/register" className="text-white underline">
+											Sign up
+										</Link>
+									</p>
+								</form>
+							</CardContent>
+						</Card>
 					</div>
 				</div>
-
-				{/* Login card */}
-				<Card className="w-full max-w-md">
-					<CardHeader>
-						<CardTitle>
-							<h2>Sign in</h2>
-						</CardTitle>
-						<CardDescription>
-							Access your Omkraft workspace
-						</CardDescription>
-					</CardHeader>
-					<CardContent>
-						<form onSubmit={handleSubmit} className="space-y-4">
-							<div className="space-y-2">
-								<Label htmlFor="email">Email</Label>
-								<Input
-									id="email"
-									type="email"
-									placeholder="you@omkraft.io"
-									value={email}
-									onChange={(e) => setEmail(e.target.value)}
-									required
-								/>
-							</div>
-
-							<div className="space-y-2">
-								<Label htmlFor="password">Password</Label>
-								<Input
-									id="password"
-									type="password"
-									value={password}
-									onChange={(e) => setPassword(e.target.value)}
-									required
-								/>
-							</div>
-
-							{error && (
-								<p className="text-sm text-destructive">
-									{error}
-								</p>
-							)}
-
-							<Button
-								type="submit"
-								className="w-full"
-								disabled={loading}
-							>
-								{loading ? 'Signing in…' : 'Login'}
-							</Button>
-
-							<p className="text-sm text-center text-muted-foreground mt-4">
-								<Link to="/forgot-password" className="text-white underline">
-									Forgot Password?
-								</Link>
-							</p>
-
-							<p className="text-sm text-center text-muted-foreground mt-4">
-								Don't have an account?{' '}
-								<Link to="/register" className="text-white underline">
-									Sign up
-								</Link>
-							</p>
-						</form>
-					</CardContent>
-				</Card>
-			</div>
-		</div>
+			) : (
+				<Loading />
+			)}
+		</>
 	);
 }


### PR DESCRIPTION
## Summary

### 🔐 Fix auth refresh behavior for public routes

#### 🐛 Problem
Login with invalid credentials incorrectly showed **“Session expired”**
because refresh-token logic was running for public auth routes.

#### ✅ Solution
- Added `skipAuthRefresh` flag to API client
- Disabled refresh retry for:
  - Login
  - Register
  - Forgot Password
  - Reset Password
  - Verify Email
- Preserved refresh-token rotation for protected APIs

#### 🎯 Result
- Correct error messages for login failures
- Clean separation between auth flows and session refresh
- More predictable and secure auth behavior

---

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Refactor
- [ ] 📚 Documentation
- [ ] 🔧 Chore

---

## Checklist
- [x] Code follows Omkraft standards
- [x] ESLint passes locally
- [x] Tests added/updated (if applicable)
- [x] No breaking changes (or documented)

---

## Screenshots / Logs (if applicable)

---

## Related Issues
Closes #
