### PR TITLE
fix(ui): improve Utility page refresh behavior by clearing stale data before new requests

### DIFF
--- a/src/pages/Utility.tsx
+++ b/src/pages/Utility.tsx
@@ -53,6 +53,8 @@ export default function Utility() {
 	const [weatherError, setWeatherError] = useState<string | null>(null);
 
 	const fetchWeather = useCallback(async () => {
+		setWeather(null);
+		setWeatherError(null);
 		try {
 			navigator.geolocation.getCurrentPosition(
 				async position => {
@@ -117,6 +119,7 @@ export default function Utility() {
 	}, []);
 
 	async function fetchQuote() {
+		setQuote(null);
 		try {
 			const data = await apiRequest<QuoteResponse>('/api/utility/quote');
 			setQuote(data);
@@ -126,6 +129,7 @@ export default function Utility() {
 	}
 
 	const fetchNews = useCallback(async (category: string) => {
+		setNews(null);
 		try {
 			const data = await apiRequest<NewsArticle[]>(
 				`/api/utility/news?category=${category}`


### PR DESCRIPTION
## Summary
This PR improves UX on the Utility page by clearing previous results before fetching fresh data.

### 🔧 Changes
- Clear `weather` and `weatherError` before `fetchWeather()` runs
- Clear `quote` before `fetchQuote()` runs
- Clear `news` before `fetchNews(category)` runs

### ✅ Why
Previously, old data could remain visible while a new request was in progress, which could be confusing.  
Now, each fetch starts from a clean state so users see only current request results.

### 🧪 Testing
- Trigger weather fetch multiple times and confirm old weather/error is cleared before new result
- Trigger quote fetch multiple times and confirm old quote is cleared before new result
- Switch news categories and confirm previous category articles are cleared before new articles load

---

## Type of Change
- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 🧹 Refactor
- [ ] 📚 Documentation
- [ ] 🔧 Chore

---

## Checklist
- [x] Code follows Omkraft standards
- [x] ESLint passes locally
- [x] Tests added/updated (if applicable)
- [x] No breaking changes (or documented)

---

## Screenshots / Logs (if applicable)

---

## Related Issues
Closes #
